### PR TITLE
fix: reuse single spinner instance in validateCommand to prevent Type…

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -103,10 +103,12 @@ export async function validateCommand(name?: string, options: { nonInteractive?:
   const results: Array<{ cast: CastConfig; result: ValidationResult }> = [];
 
   for (const cast of selectedCasts) {
+    let valSpinner: ReturnType<typeof p.spinner> | null = null;
+
     if (options.nonInteractive) {
       console.log(`Validating ${cast.title || cast.name}...`);
     } else {
-      const valSpinner = p.spinner();
+      valSpinner = p.spinner();
       valSpinner.start(`Validating ${cast.title || cast.name}...`);
     }
 
@@ -129,8 +131,7 @@ export async function validateCommand(name?: string, options: { nonInteractive?:
       if (options.nonInteractive) {
         console.log(`${icon} ${cast.title || cast.name} - ${result.status}`);
       } else {
-        const valSpinner = p.spinner();
-        valSpinner.stop(`${icon} ${cast.title || cast.name} - ${result.status}`);
+        valSpinner?.stop(`${icon} ${cast.title || cast.name} - ${result.status}`);
       }
 
     } catch (error) {
@@ -138,8 +139,7 @@ export async function validateCommand(name?: string, options: { nonInteractive?:
       if (options.nonInteractive) {
         console.log(`❌ ${cast.title || cast.name} - validation error`);
       } else {
-        const valSpinner = p.spinner();
-        valSpinner.stop(`❌ ${cast.title || cast.name} - validation error`);
+        valSpinner?.stop(`❌ ${cast.title || cast.name} - validation error`);
       }
       results.push({
         cast,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

This PR fixes an error related to calling `stop()` on a spinner instance that was not properly started, which caused runtime exceptions during validation in the CLI.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Tested with `dg init`
- [ ] Tested with `dg capture`
- [ ] Tested with `dg generate`
- [x] Tested with `dg validate`
- [ ] Tested with `dg list`
- [ ] Tested with `dg doctor`
- [ ] Tested on macOS
- [ ] Tested on Linux
- [ ] Added/updated tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- This fix improves user experience by preventing the spinner error crash during validation.
- No breaking changes introduced; only internal spinner handling logic adjusted.
