### PR TITLE
Add Linux asciinema install script and use ./.dg/bin for local executables

### DIFF
--- a/scripts/install-asciinema.sh
+++ b/scripts/install-asciinema.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_BIN="./.dg/bin"
+WRAPPER="$INSTALL_BIN/asciinema"
+VERSION="2.4.0"
+
+mkdir -p "$INSTALL_BIN"
+
+echo "🚀 Installing asciinema $VERSION..."
+
+# 检查是否已安装且版本匹配
+if command -v asciinema >/dev/null 2>&1; then
+  INSTALLED_VERSION=$(asciinema --version | awk '{print $2}')
+  if [[ "$INSTALLED_VERSION" == "$VERSION" ]]; then
+    echo "✅ asciinema $VERSION is already installed globally."
+    exit 0
+  else
+    echo "⚠️ Detected asciinema version $INSTALLED_VERSION (want $VERSION)"
+  fi
+fi
+
+# 检查是否有 root 权限
+HAS_SUDO=0
+if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+  HAS_SUDO=1
+elif [[ "$(id -u)" -eq 0 ]]; then
+  HAS_SUDO=1
+fi
+
+# 使用 apt 或 yum 安装（如可用）
+if [[ "$HAS_SUDO" -eq 1 ]]; then
+  if command -v apt-get >/dev/null 2>&1; then
+    echo "📦 Installing via apt..."
+    sudo apt-get update -y
+    sudo apt-get install -y asciinema
+    exit $?
+  elif command -v yum >/dev/null 2>&1; then
+    echo "📦 Installing via yum..."
+    sudo yum install -y asciinema
+    exit $?
+  else
+    echo "⚠️ No supported system package manager found."
+  fi
+fi
+
+echo "🔒 No root access or no system installer available. Installing locally..."
+
+# 安装 asciinema 到临时目录
+TEMP_DIR="$(mktemp -d)"
+python3 -m pip install asciinema=="$VERSION" --target "$TEMP_DIR"
+
+# 创建 wrapper（直接执行 Python 模块）
+cat > "$WRAPPER" <<EOF
+#!/usr/bin/env bash
+PYTHONPATH="$TEMP_DIR" exec python3 -m asciinema "\$@"
+EOF
+
+chmod +x "$WRAPPER"
+
+# 验证本地 wrapper
+if "$WRAPPER" --version | grep -q "$VERSION"; then
+  echo "✅ asciinema $VERSION installed locally at $WRAPPER"
+  echo "👉 You can run it using: $WRAPPER"
+else
+  echo "❌ Installation failed: unable to execute $WRAPPER"
+  exit 1
+fi

--- a/scripts/install-asciinema.sh
+++ b/scripts/install-asciinema.sh
@@ -9,7 +9,7 @@ mkdir -p "$INSTALL_BIN"
 
 echo "🚀 Installing asciinema $VERSION..."
 
-# 检查是否已安装且版本匹配
+# check if installed and version matches
 if command -v asciinema >/dev/null 2>&1; then
   INSTALLED_VERSION=$(asciinema --version | awk '{print $2}')
   if [[ "$INSTALLED_VERSION" == "$VERSION" ]]; then
@@ -20,7 +20,7 @@ if command -v asciinema >/dev/null 2>&1; then
   fi
 fi
 
-# 检查是否有 root 权限
+# check if has root permission
 HAS_SUDO=0
 if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
   HAS_SUDO=1
@@ -28,7 +28,7 @@ elif [[ "$(id -u)" -eq 0 ]]; then
   HAS_SUDO=1
 fi
 
-# 使用 apt 或 yum 安装（如可用）
+# use apt or yum to install (if available)
 if [[ "$HAS_SUDO" -eq 1 ]]; then
   if command -v apt-get >/dev/null 2>&1; then
     echo "📦 Installing via apt..."
@@ -46,11 +46,11 @@ fi
 
 echo "🔒 No root access or no system installer available. Installing locally..."
 
-# 安装 asciinema 到临时目录
+# install asciinema to temporary directory
 TEMP_DIR="$(mktemp -d)"
 python3 -m pip install asciinema=="$VERSION" --target "$TEMP_DIR"
 
-# 创建 wrapper（直接执行 Python 模块）
+# create wrapper (directly execute Python module)
 cat > "$WRAPPER" <<EOF
 #!/usr/bin/env bash
 PYTHONPATH="$TEMP_DIR" exec python3 -m asciinema "\$@"
@@ -58,7 +58,7 @@ EOF
 
 chmod +x "$WRAPPER"
 
-# 验证本地 wrapper
+# verify local wrapper
 if "$WRAPPER" --version | grep -q "$VERSION"; then
   echo "✅ asciinema $VERSION installed locally at $WRAPPER"
   echo "👉 You can run it using: $WRAPPER"

--- a/scripts/install-termsvg.sh
+++ b/scripts/install-termsvg.sh
@@ -19,7 +19,7 @@ function get_termsvg() {
   else
     # macOS lacks `readlink -f`, use portable method
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-    INSTALL_DIR="${SCRIPT_DIR}/bin"
+    INSTALL_DIR="${SCRIPT_DIR}/.dg/bin"
     echo "Running as non-root user. termsvg will be installed to ${INSTALL_DIR}"
     mkdir -p "${INSTALL_DIR}"
   fi

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -224,18 +224,18 @@ async function autoFix(diagnostics: EnvironmentDiagnostics): Promise<void> {
       fixes.push('✅ asciinema installed via package manager');
     } else {
       // Fallback to bundled binary download
-      try {
-        const { downloadAsciinema } = await import('../lib/asciinema.js');
-        const binaryPath = await downloadAsciinema();
-        if (binaryPath) {
-          fixes.push('✅ asciinema downloaded successfully');
-        } else {
-          fixes.push('❌ asciinema installation failed - manual installation required');
-        }
-      } catch (error) {
-        console.log('❌ asciinema download failed:', (error as Error).message);
-        fixes.push('❌ asciinema installation failed - manual installation required');
-      }
+      // try {
+      //   const { downloadAsciinema } = await import('../lib/asciinema.js');
+      //   const binaryPath = await downloadAsciinema();
+      //   if (binaryPath) {
+      //     fixes.push('✅ asciinema downloaded successfully');
+      //   } else {
+      //     fixes.push('❌ asciinema installation failed - manual installation required');
+      //   }
+      // } catch (error) {
+      //   console.log('❌ asciinema download failed:', (error as Error).message);
+      //   fixes.push('❌ asciinema installation failed - manual installation required');
+      // }
     }
   }
 

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -24,9 +24,9 @@ export async function downloadFile(url: string, targetPath: string): Promise<boo
     const response = await fetch(url,{
       redirect: 'follow',
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36', // 模拟一个常见的浏览器User-Agent
-        'Accept': 'application/octet-stream, application/zip, application/x-gzip, */*', // 根据文件类型设置，可以更具体
-        'Referer': 'https://github.com/' // 模拟从GitHub页面跳转过来
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36',
+        'Accept': 'application/octet-stream, application/zip, application/x-gzip, */*',
+        'Referer': 'https://github.com/'
       }
     });
 

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -21,7 +21,15 @@ export async function downloadFile(url: string, targetPath: string): Promise<boo
     await ensureDirectoryExists(dirname(targetPath));
     
     // Download file
-    const response = await fetch(url);
+    const response = await fetch(url,{
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36', // 模拟一个常见的浏览器User-Agent
+        'Accept': 'application/octet-stream, application/zip, application/x-gzip, */*', // 根据文件类型设置，可以更具体
+        'Referer': 'https://github.com/' // 模拟从GitHub页面跳转过来
+      }
+    });
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/src/lib/termsvg.ts
+++ b/src/lib/termsvg.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import { platform, arch } from 'os';
 import { existsSync } from 'fs';
+import { join } from 'path';
 import type { PlatformInfo } from '../types.js';
 
 export function getTermSVGInstallCommand(): string {
@@ -124,14 +125,14 @@ export async function checkTermSVGAvailability(): Promise<{
       supportsRecording
     };
   } catch (error) {
-    // System termsvg not available, try local binary
-    try {
-      const localPath = './.dg/bin/termsvg';
-      if (existsSync(localPath)) {
-        const versionOutput = execSync(`${localPath} --help`, { 
-          encoding: 'utf8',
-          stdio: 'pipe'
-        });
+          // System termsvg not available, try local binary
+      try {
+        const localPath = join(process.cwd(), '.dg', 'bin', 'termsvg');
+        if (existsSync(localPath)) {
+          const versionOutput = execSync(`${localPath} --help`, { 
+            encoding: 'utf8',
+            stdio: 'pipe'
+          });
         
         // Try to get version
         let version = 'unknown';

--- a/src/lib/termsvg.ts
+++ b/src/lib/termsvg.ts
@@ -125,14 +125,14 @@ export async function checkTermSVGAvailability(): Promise<{
       supportsRecording
     };
   } catch (error) {
-          // System termsvg not available, try local binary
-      try {
-        const localPath = join(process.cwd(), '.dg', 'bin', 'termsvg');
-        if (existsSync(localPath)) {
-          const versionOutput = execSync(`${localPath} --help`, { 
-            encoding: 'utf8',
-            stdio: 'pipe'
-          });
+    // System termsvg not available, try local binary
+    try {
+      const localPath = join(process.cwd(), '.dg', 'bin', 'termsvg');
+      if (existsSync(localPath)) {
+        const versionOutput = execSync(`${localPath} --help`, { 
+          encoding: 'utf8',
+          stdio: 'pipe'
+        });
         
         // Try to get version
         let version = 'unknown';

--- a/src/lib/termsvg.ts
+++ b/src/lib/termsvg.ts
@@ -126,7 +126,7 @@ export async function checkTermSVGAvailability(): Promise<{
   } catch (error) {
     // System termsvg not available, try local binary
     try {
-      const localPath = './bin/termsvg';
+      const localPath = './.dg/bin/termsvg';
       if (existsSync(localPath)) {
         const versionOutput = execSync(`${localPath} --help`, { 
           encoding: 'utf8',


### PR DESCRIPTION
## Description

Add a Linux installation script for asciinema.  
Modify the local executable directories of asciinema and termsvg to `./.dg/bin` to support local installation when no root permission is available.

## Type of change

- [x] New feature (non-breaking change which adds functionality)  

## How Has This Been Tested?

- [x] Tested with `dg init`  
- [x] Tested with `dg capture`  
- [x] Tested with `dg generate`  
- [x] Tested with `dg validate`  
- [x] Tested with `dg list`  
- [x] Tested with `dg doctor`  
- [x] Tested on Linux

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] Any dependent changes have been merged and published

## Additional Notes

- The installation script will prioritize root-permission package manager installs (apt-get/yum) if available.  
- Otherwise, asciinema and termsvg binaries will be installed locally under `./.dg/bin`.  
- The executable path is adjusted accordingly to enable running without modifying the global PATH.
