### PR TITLE
feat: support terminal recording via termsvg instead of asciinema

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -8,9 +8,9 @@ import {
   updateCast
 } from '../lib/config.js';
 import {
-  checkAsciinemaAvailability,
+  checkTermSVGAvailability,
   recordInteractiveDemo
-} from '../lib/asciinema.js';
+} from '../lib/termsvg.js';
 import { detectInteractiveElements } from '../lib/interactive-detection.js';
 import { generateSVG } from '../lib/svg-generation.js';
 import { initLogger, dgLogger as logger } from '../lib/logger.js';
@@ -50,15 +50,15 @@ export async function captureCommand(options: {
     return;
   }
 
-  const asciinemaCheck = await checkAsciinemaAvailability();
+  const termsvgCheck = await checkTermSVGAvailability();
 
-  if (!asciinemaCheck.available) {
-    logger.error('asciinema not available', { version: asciinemaCheck.version });
-    p.cancel('asciinema is required for recording. Install it first or run with DG_GPL_OFF=0.');
+  if (!termsvgCheck.available) {
+    logger.error('termsvg not available', { version: termsvgCheck.version });
+    p.cancel('termsvgCheck is required for recording. Install it first');
     return;
   }
 
-  logger.debug('asciinema check passed', { version: asciinemaCheck.version });
+  logger.debug('termsvg check passed', { version: termsvgCheck.version });
 
   // Only ask for title
   const title = await p.text({
@@ -110,7 +110,7 @@ export async function captureCommand(options: {
 
   if (!recordSuccess) {
     logger.error('Recording failed');
-    p.cancel('Recording failed. Check that asciinema is working properly.');
+    p.cancel('Recording failed. Check that termsvg is working properly.');
     return;
   }
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,7 +13,8 @@ export async function doctorCommand(options?: any): Promise<void> {
   p.intro('🩺 System Diagnostics');
   
   const diagnostics: EnvironmentDiagnostics = {
-    asciinema: await checkAsciinema(),
+    // ignore asciinema for now
+    // asciinema: await checkAsciinema(),
     svgTerm: await checkTermSVG(),
     storage: await checkStorage(),
     platform: await checkPlatform()
@@ -88,7 +89,7 @@ async function checkTermSVG(): Promise<DiagnosticResult> {
     };
   } else {
     return {
-      status: 'warning',
+      status: 'error',
       message: 'termsvg not available',
       details: availability.installCommand || 'Install from: https://github.com/MrMarble/termsvg'
     };
@@ -215,7 +216,7 @@ async function autoFix(diagnostics: EnvironmentDiagnostics): Promise<void> {
   const fixes: string[] = [];
   
   // Auto-fix asciinema installation
-  if (diagnostics.asciinema.status === 'error') {
+  if (diagnostics?.asciinema?.status === 'error') {
     console.log('\n🔧 Attempting to install asciinema...');
     
     // Try system package manager first
@@ -240,7 +241,7 @@ async function autoFix(diagnostics: EnvironmentDiagnostics): Promise<void> {
   }
 
   // Auto-fix termsvg installation
-  if (diagnostics.svgTerm.status === 'warning' && diagnostics.svgTerm.message.includes('not available')) {
+  if (diagnostics.svgTerm.status === 'error' && diagnostics.svgTerm.message.includes('not available')) {
     console.log('\n🔧 Attempting to install termsvg...');
     const installed = await installTermSVGInteractive();
     if (installed) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,7 @@ import {
 } from '../lib/config.js';
 import { join } from 'path';
 import { ensureDirectoryExists } from '../lib/file.js';
+import { checkTermSVGAvailability, installTermSVGInteractive } from '../lib/termsvg.js';
 
 const GITHUB_WORKFLOW = `name: DeepGuide
 
@@ -34,11 +35,6 @@ jobs:
     
     - name: Install dependencies
       run: npm install
-      
-    - name: Install asciinema
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y asciinema
     
     - name: Validate demos
       run: npx @deepguide-ai/dg validate --non-interactive
@@ -81,26 +77,26 @@ export async function initCommand(): Promise<void> {
   const spinner = p.spinner();
   spinner.start('Checking dependencies...');
   
-  // Check asciinema
-  const asciinemaCheck = await checkAsciinemaAvailability();
-  if (asciinemaCheck.available) {
-    spinner.stop(`✅ Using ${asciinemaCheck.source} asciinema v${asciinemaCheck.version}`);
+  // Check termsvg
+  const termsvgCheck = await checkTermSVGAvailability();
+  if (termsvgCheck.available) {
+    spinner.stop(`✅ Using termsvg v${termsvgCheck.version}`);
   } else {
-    spinner.stop('⚠️  asciinema not found');
-    
-    const shouldDownload = await p.confirm({
-      message: 'Would you like me to download asciinema for you?',
+    spinner.stop('⚠️  termsvg not found');
+
+    const shouldInstall = await p.confirm({
+      message: 'Would you like me to install termsvg for you?',
       initialValue: true
     });
     
-    if (shouldDownload) {
-      spinner.start('Downloading asciinema...');
-      const binaryPath = await downloadAsciinema();
+    if (shouldInstall) {
+      spinner.start('Installing termsvg...');
+      const installed = await installTermSVGInteractive();
       
-      if (binaryPath) {
-        spinner.stop('✅ Downloaded asciinema successfully');
+      if (installed) {
+        spinner.stop('✅ Installed termsvg successfully');
       } else {
-        spinner.stop('❌ Failed to download asciinema');
+        spinner.stop('❌ Failed to install termsvg');
         const shouldContinue = await p.confirm({
           message: 'Continue anyway? (You can install it later)',
           initialValue: true

--- a/src/lib/termsvg.ts
+++ b/src/lib/termsvg.ts
@@ -3,6 +3,7 @@ import { platform, arch } from 'os';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import type { PlatformInfo } from '../types.js';
+import { safeDeleteExistingCast } from './file.js';
 
 export function getTermSVGInstallCommand(): string {
   const currentPlatform = platform();
@@ -80,9 +81,11 @@ export async function checkTermSVGAvailability(): Promise<{
   installCommand?: string;
   installInstructions?: string[];
 }> {
-  // First try system termsvg
+  const termsvgPath = getTermSVGPath();
+  
   try {
-    const versionOutput = execSync('termsvg --help', { 
+    // Check if termsvg is available
+    const versionOutput = execSync(`"${termsvgPath}" --help`, { 
       encoding: 'utf8',
       stdio: 'pipe'
     });
@@ -90,7 +93,7 @@ export async function checkTermSVGAvailability(): Promise<{
     // Try to get version from help output or version command
     let version = 'unknown';
     try {
-      const versionCheck = execSync('termsvg --version', { 
+      const versionCheck = execSync(`"${termsvgPath}" --version`, { 
         encoding: 'utf8',
         stdio: 'pipe'
       });
@@ -106,18 +109,6 @@ export async function checkTermSVGAvailability(): Promise<{
     // Check which commands are available
     const supportsRecording = versionOutput.includes('rec') && platform() !== 'win32';
     
-    // Try to get the path
-    let termsvgPath = 'termsvg';
-    try {
-      const whichOutput = execSync(platform() === 'win32' ? 'where termsvg' : 'which termsvg', {
-        encoding: 'utf8',
-        stdio: 'pipe'
-      });
-      termsvgPath = whichOutput.trim().split('\n')[0];
-    } catch {
-      // Keep default if which/where fails
-    }
-    
     return {
       available: true,
       version,
@@ -125,42 +116,6 @@ export async function checkTermSVGAvailability(): Promise<{
       supportsRecording
     };
   } catch (error) {
-    // System termsvg not available, try local binary
-    try {
-      const localPath = join(process.cwd(), '.dg', 'bin', 'termsvg');
-      if (existsSync(localPath)) {
-        const versionOutput = execSync(`${localPath} --help`, { 
-          encoding: 'utf8',
-          stdio: 'pipe'
-        });
-        
-        // Try to get version
-        let version = 'unknown';
-        try {
-          const versionCheck = execSync(`${localPath} --version`, { 
-            encoding: 'utf8',
-            stdio: 'pipe'
-          });
-          version = versionCheck.trim();
-        } catch {
-          const versionMatch = versionOutput.match(/termsvg\s+v?(\d+\.\d+\.\d+)/i);
-          if (versionMatch) {
-            version = versionMatch[1];
-          }
-        }
-        
-        const supportsRecording = versionOutput.includes('rec') && platform() !== 'win32';
-        
-        return {
-          available: true,
-          version,
-          path: localPath,
-          supportsRecording
-        };
-      }
-    } catch (localError) {
-      // Local binary also not available
-    }
     
     return {
       available: false,
@@ -171,7 +126,17 @@ export async function checkTermSVGAvailability(): Promise<{
   }
 }
 
-
+export function getTermSVGPath(): string {
+  // Check local installation first
+  const localPath = join(process.cwd(), '.dg', 'bin', 'termsvg');
+  
+  if (existsSync(localPath)) {
+    return localPath;
+  }
+  
+  // Fallback to PATH
+  return 'termsvg';
+}
 
 export async function installTermSVGInteractive(): Promise<boolean> {
   const currentPlatform = platform();
@@ -181,29 +146,6 @@ export async function installTermSVGInteractive(): Promise<boolean> {
   try {
     switch (currentPlatform) {
       case 'darwin':
-        console.log('📦 Attempting to install via remote script...');
-        try {
-          // Check if this is a global installation
-          const isGlobalInstall = process.env.npm_config_global === 'true' || 
-                                 process.env.npm_config_prefix || 
-                                 process.argv.includes('--global');
-          
-          const installCommand = isGlobalInstall 
-            ? 'curl -sL https://raw.githubusercontent.com/DeepGuide-Ai/dg/master/scripts/install-termsvg.sh | sudo -E bash -'
-            : 'curl -sL https://raw.githubusercontent.com/DeepGuide-Ai/dg/master/scripts/install-termsvg.sh | bash -';
-          
-          execSync(installCommand, { stdio: 'inherit' });
-          console.log('✅ termsvg installed successfully!');
-          return true;
-        } catch (installError) {
-          console.log('❌ Remote install script failed');
-          console.log('💡 Please install manually:');
-          console.log('   # Try Go installation:');
-          console.log('   go install github.com/mrmarble/termsvg/cmd/termsvg@latest');
-          console.log('   # Or download from: https://github.com/MrMarble/termsvg/releases');
-          return false;
-        }
-        
       case 'linux':
         console.log('📦 Attempting to install via remote script...');
         try {
@@ -295,6 +237,284 @@ export async function exportSVG(
     } else {
       console.log('💡 Check that termsvg is working properly.');
       console.log(`   Test: ${termsvgPath} --help`);
+    }
+    
+    return false;
+  }
+} 
+
+export async function recordInteractiveDemo(
+  outputPath: string, 
+  options: { 
+    cols?: number; 
+    rows?: number; 
+    env?: Record<string, string>;
+    overwrite?: boolean;
+    onCommand?: (command: string) => void;
+  } = {}
+): Promise<boolean> {
+  const availability = await checkTermSVGAvailability();
+  if (!availability.available) {
+    console.error('termsvg not available');
+    console.log('💡 Install termsvg:');
+    getTermSVGInstallInstructions().forEach(line => console.log('   ' + line));
+    return false;
+  }
+  
+  if (!availability.supportsRecording) {
+      console.error('termsvg does not support recording on this platform');
+      console.log('💡 Recording is not supported on Windows');
+      return false;
+    }
+  
+  const termsvgPath = availability.path || 'termsvg';
+  const { cols = 120, rows = 30, env = {}, overwrite = false, onCommand } = options;
+  
+  // Proactively delete existing cast file if overwrite is requested
+  if (overwrite) {
+    if (existsSync(outputPath)) {
+      const deleteSuccess = safeDeleteExistingCast(outputPath);
+      if (!deleteSuccess) {
+        return false;
+      }
+    }
+  }
+  
+  const recordEnv = {
+    ...process.env,
+    ...env,
+    // Terminal dimensions
+    COLUMNS: cols.toString(),
+    LINES: rows.toString(),
+    // Terminal type and capabilities
+    TERM: 'xterm-256color',
+    // Fix cursor positioning issues
+    LANG: 'en_US.UTF-8',
+    LC_ALL: 'en_US.UTF-8',
+    // Suppress shell initialization and prompts
+    SHELL: '/bin/sh', // Force basic shell
+    PS1: '', // Empty prompt
+    PS2: '',
+    PS3: '',
+    PS4: '',
+    PROMPT_COMMAND: '',
+    // Disable shell history and rc files
+    HISTFILE: '/dev/null',
+    HISTSIZE: '0',
+    HISTFILESIZE: '0',
+    HISTCONTROL: 'ignoreboth',
+    // Disable all shell rc/profile files
+    ZDOTDIR: '/dev/null',
+    BASH_ENV: '/dev/null',
+    ENV: '/dev/null',
+    BASHRC: '/dev/null',
+    BASH_PROFILE: '/dev/null',
+    PROFILE: '/dev/null',
+    // Force non-interactive mode
+    PS0: '',
+    RPROMPT: '',
+    RPS1: '',
+    RPS2: '',
+    // Prevent cursor positioning issues
+    ZLE_RPROMPT_INDENT: '0',
+    // Disable shell completion
+    FIGNORE: '*',
+    BASH_COMPLETION_USER_DIR: '/dev/null'
+  };
+  
+  try {
+    // Import node-pty for interactive recording
+    const pty = await import('node-pty');
+
+    // Create a PTY instance with proper configuration
+    // termsvg rec only takes the output file as argument, no --cols/--rows flags
+    const ptyProcess = pty.spawn(termsvgPath, ['rec', outputPath], {
+      name: 'xterm-256color',
+      cols,
+      rows,
+      env: recordEnv,
+      cwd: process.cwd()
+    });
+
+    // Set up raw mode for input
+    process.stdin.setRawMode?.(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('utf8');
+
+    // Forward PTY output to stdout
+    ptyProcess.onData((data) => {
+      try {
+        process.stdout.write(data.toString());
+      } catch (err) {
+        console.error('Error writing to stdout:', err);
+      }
+    });
+
+    // Forward user input to PTY
+    let currentCommand = '';
+    process.stdin.on('data', (data) => {
+      try {
+        const str = data.toString();
+        if (str === '\r' || str === '\n') {
+          if (currentCommand.trim() && onCommand) {
+            onCommand(currentCommand.trim());
+          }
+          currentCommand = '';
+        } else if (str === '\u007f' || str === '\b') { // Backspace
+          currentCommand = currentCommand.slice(0, -1);
+        } else {
+          currentCommand += str;
+        }
+        ptyProcess.write(str);
+      } catch (err) {
+        console.error('Error writing to pty:', err);
+      }
+    });
+
+    // Handle terminal session end
+    ptyProcess.onExit(() => {
+      // Clean up terminal state
+      process.stdin.setRawMode?.(false);
+      process.stdin.pause();
+      process.stdin.setEncoding('utf8');
+      process.stdout.write('\r\n');
+    });
+
+    // Handle Ctrl+C
+    process.on('SIGINT', () => {
+      ptyProcess.kill();
+    });
+
+    // Wait for the process to exit
+    return new Promise((resolve) => {
+      ptyProcess.onExit(({ exitCode }) => {
+        // Clean up
+        process.stdin.setRawMode?.(false);
+        process.stdin.pause();
+        process.stdin.removeAllListeners('data');
+        process.removeAllListeners('SIGINT');
+        resolve(exitCode === 0);
+      });
+    });
+  } catch (error) {
+    const errorMessage = (error as Error).message;
+    console.error('Recording failed:', errorMessage);
+    
+    // Enhanced error handling with specific solutions
+    if (errorMessage.includes('already exists')) {
+      console.log('❌ Cast file still exists after deletion attempt');
+      console.log('💡 Possible solutions:');
+      console.log('   1. Delete the file manually:', outputPath);
+      console.log('   2. Check file permissions');
+      console.log('   3. Close any applications that might be using the file');
+    } else if (errorMessage.includes('command not found') || errorMessage.includes('No such file')) {
+      console.log('💡 termsvg not found. Install it:');
+      getTermSVGInstallInstructions().forEach(line => console.log('   ' + line));
+    } else if (errorMessage.includes('Permission denied')) {
+      console.log('💡 Permission denied. Try:');
+      console.log('   1. Check file/directory permissions');
+      console.log('   2. Run with appropriate permissions');
+      console.log('   3. Ensure output directory is writable');
+    } else if (errorMessage.includes('timeout') || errorMessage.includes('killed')) {
+      console.log('💡 Recording timed out or was interrupted');
+      console.log('   This is normal if you pressed Ctrl+C to stop recording');
+    } else {
+      console.log('💡 Unexpected error. Debug steps:');
+      console.log(`   1. Test: ${termsvgPath} --help`);
+      console.log('   2. Check terminal compatibility');
+      console.log('   3. Try recording manually: termsvg rec test.cast');
+    }
+    return false;
+  }
+}
+
+export async function recordDemo(
+  command: string, 
+  outputPath: string, 
+  options: { 
+    cols?: number; 
+    rows?: number; 
+    env?: Record<string, string>;
+    overwrite?: boolean;
+  } = {}
+): Promise<boolean> {
+  const availability = await checkTermSVGAvailability();
+  if (!availability.available) {
+    console.error('termsvg not available');
+    console.log('💡 Install termsvg:');
+    getTermSVGInstallInstructions().forEach(line => console.log('   ' + line));
+    return false;
+  }
+  
+  if (!availability.supportsRecording) {
+      console.error('termsvg does not support recording on this platform');
+      console.log('💡 Recording is not supported on Windows');
+      return false;
+    }
+  
+  const termsvgPath = availability.path || 'termsvg';
+  const { cols = 120, rows = 30, env = {}, overwrite = false } = options;
+  
+  // Proactively delete existing cast file if overwrite is requested
+  if (overwrite) {
+    if (existsSync(outputPath)) {
+      const deleteSuccess = safeDeleteExistingCast(outputPath);
+      if (!deleteSuccess) {
+        return false;
+      }
+    }
+  }
+  
+  const recordEnv = {
+    ...process.env,
+    ...env,
+    COLUMNS: cols.toString(),
+    LINES: rows.toString(),
+    TERM: 'xterm-256color'
+  };
+  
+  try {
+    // termsvg rec only takes the output file as argument, and -c for command
+    const args = [
+      `"${termsvgPath}"`,
+      'rec',
+      `"${outputPath}"`,
+      '-c', `"${command}"`
+    ];
+    
+    execSync(args.join(' '), {
+      env: recordEnv,
+      stdio: 'inherit'
+    });
+    
+    return true;
+  } catch (error) {
+    const errorMessage = (error as Error).message;
+    console.error('Recording failed:', errorMessage);
+    
+    // Enhanced error handling with specific solutions
+    if (errorMessage.includes('already exists')) {
+      console.log('❌ Cast file still exists after deletion attempt');
+      console.log('💡 Possible solutions:');
+      console.log('   1. Delete the file manually:', outputPath);
+      console.log('   2. Check file permissions');
+      console.log('   3. Close any applications that might be using the file');
+    } else if (errorMessage.includes('command not found') || errorMessage.includes('No such file')) {
+      console.log('💡 termsvg not found. Install it:');
+      getTermSVGInstallInstructions().forEach(line => console.log('   ' + line));
+    } else if (errorMessage.includes('Permission denied')) {
+      console.log('💡 Permission denied. Try:');
+      console.log('   1. Check file/directory permissions');
+      console.log('   2. Run with appropriate permissions');
+      console.log('   3. Ensure output directory is writable');
+    } else if (errorMessage.includes('timeout') || errorMessage.includes('killed')) {
+      console.log('💡 Recording timed out or was interrupted');
+      console.log('   This is normal if you pressed Ctrl+C to stop recording');
+    } else {
+      console.log('💡 Unexpected error. Debug steps:');
+      console.log(`   1. Test: ${termsvgPath} --help`);
+      console.log('   2. Check terminal compatibility');
+      console.log(`   3. Try recording manually: ${termsvgPath} rec test.cast`);
     }
     
     return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export interface DiagnosticResult {
 }
 
 export interface EnvironmentDiagnostics {
-  asciinema: DiagnosticResult;
+  asciinema?: DiagnosticResult;
   svgTerm: DiagnosticResult;
   storage: DiagnosticResult;
   platform: DiagnosticResult;


### PR DESCRIPTION
## Description

Replaced `asciinema` with [`termsvg`](https://github.com/marionebl/termsvg) for terminal recording to improve compatibility and reduce dependencies. This simplifies installation and avoids runtime issues with Python or asciinema versions on certain platforms (e.g., macOS 10.15).

Fixes: N/A

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested with `dg init`
- [x] Tested with `dg capture`
- [x] Tested with `dg generate`
- [x] Tested with `dg validate`
- [x] Tested with `dg list`
- [x] Tested with `dg doctor`
- [x] Tested on macOS (10.15, 12.x)
- [x] Tested on Linux (Ubuntu 20.04+)
- [ ] Added/updated tests (N/A, CLI integration only)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- `termsvg` is installed via a script under `scripts/install`, with fallback for environments without `go`.
- Legacy support for asciinema has been removed.
