### PR TITLE
fix: ensure node-pty native module is properly built during installation

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -50,6 +50,13 @@ function tryRebuildNodePtyManually() {
 
 async function install() {
   try {
+    // check if node-pty is installed
+    const ok = tryLoadNodePty();
+    if (!ok) {
+      // if module load failed, try to rebuild node-pty manually
+      tryRebuildNodePtyManually();
+    }
+
     // Check if dist/index.js exists (built version)
     const distPath = join(process.cwd(), 'dist', 'index.js');
     
@@ -57,12 +64,6 @@ async function install() {
       console.log('⚠️ Built files not found. This is normal during development.');
       console.log('Run `npm run build` to build the project.');
       return;
-    }
-
-    const ok = tryLoadNodePty();
-    if (!ok) {
-      // if module load failed, try to rebuild node-pty manually
-      tryRebuildNodePtyManually();
     }
 
     console.log('✓ DeepGuide CLI installed successfully!');

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,7 +1,52 @@
 #!/usr/bin/env node
 
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { createRequire } from 'module';
+import { execSync } from 'child_process';
+
+const requireCJS = createRequire(import.meta.url);
+function tryLoadNodePty() {
+  try {
+    // try to load node-pty
+    requireCJS('node-pty');
+    console.log('✅ node-pty loaded successfully');
+    return true;
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      console.warn('❌ node-pty module not found.');
+    } else {
+      console.warn('⚠️ node-pty load failed:', err.message);
+    }
+    return false;
+  }
+}
+
+function tryRebuildNodePtyManually() {
+  try {
+    // locate node-pty directory
+    const resolvedPath = requireCJS.resolve('node-pty');
+    const moduleDir = dirname(dirname(resolvedPath)); // one up from `lib/index.js`
+    console.log('📍 node-pty found at:', moduleDir);
+
+    // check if binding.gyp exists, confirm it's a source directory
+    const gypPath = join(moduleDir, 'binding.gyp');
+    if (!existsSync(gypPath)) {
+      console.warn('⚠️ node-pty does not appear to be from source (binding.gyp not found)');
+      return;
+    }
+
+    console.log('🔧 Rebuilding node-pty via node-gyp...');
+    execSync('npx node-gyp rebuild', {
+      cwd: moduleDir,
+      stdio: 'inherit',
+    });
+
+    console.log('✅ node-pty rebuilt successfully via node-gyp');
+  } catch (err) {
+    console.error('❌ Failed to rebuild node-pty manually:', err.message);
+  }
+}
 
 async function install() {
   try {
@@ -12,6 +57,12 @@ async function install() {
       console.log('⚠️ Built files not found. This is normal during development.');
       console.log('Run `npm run build` to build the project.');
       return;
+    }
+
+    const ok = tryLoadNodePty();
+    if (!ok) {
+      // if module load failed, try to rebuild node-pty manually
+      tryRebuildNodePtyManually();
     }
 
     console.log('✓ DeepGuide CLI installed successfully!');


### PR DESCRIPTION
## Description

This PR fixes the issue where the `node-pty` native module might not be properly built during installation, causing runtime errors due to missing native bindings.
It adds a postinstall script that verifies the presence and loadability of the native `.node` binary, and attempts to rebuild `node-pty` automatically using `node-gyp` if necessary, improving the robustness of the installation process.

## Type of change

Please delete options that are not relevant.

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Performance improvement
* [ ] Code refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

* [x] Tested with `dg init`
* [x] Tested with `dg capture`
* [x] Tested with `dg generate`
* [x] Tested with `dg validate`
* [x] Tested with `dg list`
* [x] Tested with `dg doctor`
* [x] Tested on macOS
* [x] Tested on Linux
* [ ] Added/updated tests

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] Any dependent changes have been merged and published

## Additional Notes

This automated check and rebuild script reduces common native module installation issues, especially when using pnpm or other package managers that may interfere with native build steps.
